### PR TITLE
add option for asset_path to be relative

### DIFF
--- a/lib/middleman/condenser.rb
+++ b/lib/middleman/condenser.rb
@@ -124,9 +124,10 @@ class Middleman::Condenser < ::Middleman::Extension
       source = kind if source.nil?
 
       asset = app.condenser.find_export(source, accept: accept)
+      
       if asset
         app.extensions[:condenser].export(source)
-        "/#{app.extensions[:condenser].options[:prefix].gsub(/^\//, '')}/#{asset.path}"
+        "#{options[:relative] ? "" : "/"}#{app.extensions[:condenser].options[:prefix].gsub(/^\//, '')}/#{asset.path}"
       else
         super
       end

--- a/lib/middleman/condenser.rb
+++ b/lib/middleman/condenser.rb
@@ -127,7 +127,7 @@ class Middleman::Condenser < ::Middleman::Extension
       
       if asset
         app.extensions[:condenser].export(source)
-        "#{options[:relative] ? "" : "/"}#{app.extensions[:condenser].options[:prefix].gsub(/^\//, '')}/#{asset.path}"
+        "#{app.config[:asset_host] || "/" + app.extensions[:condenser].options[:prefix].gsub(/^\//, '')}/#{asset.path}"
       else
         super
       end


### PR DESCRIPTION
Github page's default url for a repo is a site in a folder, so need ability for sites to have a `<base>` and relative assets to that base.

Example
```html
<html>
<header>
    <base href="https://bemky.github.io/mdarea">
    <link href="assets/main-5fe311266f5839bb33b095836a9231a27afacd4c49e6adfa35c28443a7bf5c44.css" rel="stylesheet" />
```
vs
```html
<html>
<header>
    <base href="https://bemky.github.io/mdarea">
    <link href="/assets/main-5fe311266f5839bb33b095836a9231a27afacd4c49e6adfa35c28443a7bf5c44.css" rel="stylesheet" />
```
Leading slash (absolute pathing) does not allow url to work.

This is supported by Middleman's native `asset_path`: https://github.com/middleman/middleman/blob/48c97b22ff25e22a2533fb5b4128337b5a97e080/middleman-core/lib/middleman-core/util/paths.rb#L186