### PR TITLE
App Asset Host

### DIFF
--- a/lib/middleman/condenser.rb
+++ b/lib/middleman/condenser.rb
@@ -79,11 +79,15 @@ class Middleman::Condenser < ::Middleman::Extension
   end
 
   def after_configuration
-    prefix = File.join(*[app.config[:host], app.extensions[:condenser].options[:prefix]].compact)
+    prefix = [
+      app.config[:asset_host] || app.config[:host],
+      app.extensions[:condenser].options[:prefix]
+    ].compact.reduce{|final, item| final + "/" + item.delete_prefix("/").delete_suffix("/")}
+    
     @condenser.context_class.class_eval <<~RUBY
       def asset_path(path, options = {})
         @environment.instance_variable_get(:@middleman_app).extensions[:condenser].export(path)
-        File.join("#{prefix}", @environment.find(path, options).path)
+        ["#{prefix}", @environment.find(path, options).path].join("/")
       end
     RUBY
   end
@@ -127,7 +131,11 @@ class Middleman::Condenser < ::Middleman::Extension
       
       if asset
         app.extensions[:condenser].export(source)
-        "#{app.config[:asset_host] || "/" + app.extensions[:condenser].options[:prefix].gsub(/^\//, '')}/#{asset.path}"
+        [
+          app.config[:asset_host] || app.config[:host],
+          app.extensions[:condenser].options[:prefix],
+          asset.path
+        ].compact.reduce{|final, item| final + "/" + item.delete_prefix("/").delete_suffix("/")}
       else
         super
       end

--- a/lib/middleman/condenser.rb
+++ b/lib/middleman/condenser.rb
@@ -124,9 +124,10 @@ class Middleman::Condenser < ::Middleman::Extension
       source = kind if source.nil?
 
       asset = app.condenser.find_export(source, accept: accept)
+      
       if asset
         app.extensions[:condenser].export(source)
-        "/#{app.extensions[:condenser].options[:prefix].gsub(/^\//, '')}/#{asset.path}"
+        "#{options[:relative] ? "" : "/"}#{app.extensions[:condenser].options[:prefix].gsub(/^\//, '')}/#{asset.path}"
       else
         super
       end

--- a/lib/middleman/condenser.rb
+++ b/lib/middleman/condenser.rb
@@ -127,7 +127,7 @@ class Middleman::Condenser < ::Middleman::Extension
       
       if asset
         app.extensions[:condenser].export(source)
-        "#{options[:relative] ? "" : "/"}#{app.extensions[:condenser].options[:prefix].gsub(/^\//, '')}/#{asset.path}"
+        "#{app.config[:asset_host] || "/" + app.extensions[:condenser].options[:prefix].gsub(/^\//, '')}/#{asset.path}"
       else
         super
       end


### PR DESCRIPTION
Github page's default url for a repo is a site in a folder, so need ability to set asset_host.

Example
```html
<html>
<header>
    <link href="https://bemky.github.io/mdarea/assets/main-5fe311266f5839bb33b095836a9231a27afacd4c49e6adfa35c28443a7bf5c44.css" rel="stylesheet" />
```
vs
```html
<html>
<header>
    <link href="/assets/main-5fe311266f5839bb33b095836a9231a27afacd4c49e6adfa35c28443a7bf5c44.css" rel="stylesheet" />
```