### PR TITLE
Only add required_asset if not already added

### DIFF
--- a/lib/middleman/condenser.rb
+++ b/lib/middleman/condenser.rb
@@ -75,7 +75,7 @@ class Middleman::Condenser < ::Middleman::Extension
   end
   
   def export(file)
-    @required_assets << file if @required_assets
+    @required_assets << file if @required_assets && @required_assets.exclude?(file)
   end
 
   def after_configuration


### PR DESCRIPTION
Ran into problem with Uniform where an asset was referenced more than once, and it caused the asset to be processed many times on build.